### PR TITLE
renovateで、majorバージョンを自動アップデートしないようにした

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "timezone": "Asia/Tokyo",
   "labels": ["renovate"],
   "assignees": ["Itsuki54"],
+  "matchUpdateTypes": ["minor", "patch"],
   "automerge": true,
   "automergeType": "pr",
   "rebaseWhen": "automerging"


### PR DESCRIPTION
tailwindのmajorバージョンの自動マージが走ってしまったことを確認したので、修正します